### PR TITLE
Make spec.fm link clickable.

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -280,10 +280,10 @@ const Experience = ({ data }) => {
             I co-founded a podcast network called Spec for designers and
             developers who want to level up in their careers. Spec hosts
             episodes from 13 different podcasts today, with millions of listens.
-            <IconWrap>
-              <SpecLogo />
-            </IconWrap>
           </div>
+          <IconWrap>
+            <SpecLogo />
+          </IconWrap>
         </div>
       </CurrentWork>
 


### PR DESCRIPTION
The Spec.fm link is not clickable on the homepage because the background image seems to get in the way.